### PR TITLE
Bash script to change proxy every so often

### DIFF
--- a/updateproxy.sh
+++ b/updateproxy.sh
@@ -8,7 +8,7 @@ DELAY=$2
 
 #Check if arg was received
 if [ -z "$2" ]; then 
-	echo "USAGE: ./updateproxy.sh <number-of-repetitions <delay-between-repetitions>"
+	echo "USAGE: ./updateproxy.sh <number-of-repetitions> <delay-between-repetitions>"
 	exit
 fi
 

--- a/updateproxy.sh
+++ b/updateproxy.sh
@@ -15,9 +15,9 @@ fi
 #iptables dropping packets makes sure your real ip isn't leaked if webpage
 #is being fetched during the proxy reload.
 while [ $COUNTER -lt $MAX ]; do
-	iptables -P OUTPUT DROP
+	iptables -w -P OUTPUT DROP
 	python $FILE -l
-	iptables -P OUTPUT ACCEPT
+	iptables -w -P OUTPUT ACCEPT
 	sleep $DELAY
 	let COUNTER=COUNTER+1
 done

--- a/updateproxy.sh
+++ b/updateproxy.sh
@@ -8,12 +8,16 @@ DELAY=$2
 
 #Check if arg was received
 if [ -z "$2" ]; then 
-	echo "USAGE: ./updateproxy.sh <number-of-repetitions> <delay-between-repetitions>"
+	echo "USAGE: sudo ./updateproxy.sh <number-of-repetitions> <delay-between-repetitions>"
 	exit
 fi
 
+#iptables dropping packets makes sure your real ip isn't leaked if webpage
+#is being fetched during the proxy reload.
 while [ $COUNTER -lt $MAX ]; do
+	iptables -P OUTPUT DROP
 	python $FILE -l
+	iptables -P OUTPUT ACCEPT
 	sleep $DELAY
 	let COUNTER=COUNTER+1
 done

--- a/updateproxy.sh
+++ b/updateproxy.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+#Change proxy every DELAY seconds for MAX times
+FILE=./toriptables2.py
+COUNTER=0
+MAX=$1 #
+DELAY=$2
+
+#Check if arg was received
+if [ -z "$2" ]; then 
+	echo "USAGE: ./updateproxy.sh <number-of-repetitions <delay-between-repetitions>"
+	exit
+fi
+
+while [ $COUNTER -lt $MAX ]; do
+	python $FILE -l
+	sleep $DELAY
+	let COUNTER=COUNTER+1
+done

--- a/updateproxy.sh
+++ b/updateproxy.sh
@@ -3,12 +3,12 @@
 #Change proxy every DELAY seconds for MAX times
 FILE=./toriptables2.py
 COUNTER=0
-MAX=$1 #
+MAX=$1
 DELAY=$2
 
 #Check if arg was received
 if [ -z "$2" ]; then 
-	echo "USAGE: sudo ./updateproxy.sh <number-of-repetitions> <delay-between-repetitions>"
+	echo "USAGE: sudo ${0} <number-of-repetitions> <delay-between-repetitions>"
 	exit
 fi
 

--- a/updateproxy.sh
+++ b/updateproxy.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 
 #Change proxy every DELAY seconds for MAX times
-FILE=./toriptables2.py
+FILE=toriptables2.py
 COUNTER=0
-MAX=$1
+MAX=$1 #
 DELAY=$2
 
-#Check if arg was received
-if [ -z "$2" ]; then 
+#Check if args was received
+if [ $# -ne 2 ]; then 
 	echo "USAGE: sudo ${0} <number-of-repetitions> <delay-between-repetitions>"
 	exit
 fi
 
 #iptables dropping packets makes sure your real ip isn't leaked if webpage
 #is being fetched during the proxy reload.
-while [ $COUNTER -lt $MAX ]; do
+while [ ${COUNTER} -lt ${MAX} ]; do
 	iptables -w -P OUTPUT DROP
-	python $FILE -l
+	${FILE} -l
 	iptables -w -P OUTPUT ACCEPT
-	sleep $DELAY
-	let COUNTER=COUNTER+1
+	sleep ${DELAY}
+	let "COUNTER += 1"
 done


### PR DESCRIPTION
A simple bash script that runs toriptables2 repeatedly, with number of repetitions and delay between them up to the user.

Delay is by default in seconds, however it can also be any acceptable argument for sleep command (man 1 sleep).

Useful since using same proxy all the time still lets people follow you and identify you from your digital footprint, while changing it at least once per few hours improves your anonymity greatly.

Script needs to be ran in the folder in which toriptables2.py is.

Usage: sudo ./updateproxy.sh <number-of-repetitions> <delay-between repetitions>